### PR TITLE
Fix background image responsiveness for smaller screen sizes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3,12 +3,16 @@
     padding: 0;
 }
 
-.main {
+body{
     width: 100%;
-    background: linear-gradient(to top, rgba(0, 0, 0, 0.5)50%, rgba(0, 0, 0, 0.5)50%), url(bg.jpg);
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.5) 50%, rgba(0, 0, 0, 0.5) 50%), url(bg.jpg);
     background-position: center;
     background-size: cover;
-    height: 100vh;
+    background-attachment: fixed; 
+    background-repeat: no-repeat; 
+    height: auto;
+    min-height: 100vh;
+    position: relative;
 }
 
 .navbar {


### PR DESCRIPTION
This PR fixes an issue where the background image did not properly cover the entire viewport on smaller screen sizes. The image failed to maintain full coverage when the screen was resized or scrolled.

Fixes: #11 

**Changes Made:**
-Updated CSS to ensure the background image covers the entire viewport, regardless of screen size.
-Tested across multiple screen sizes to ensure consistent behavior.
-Confirmed that no visual issues occur when scrolling or resizing the window.

![Screenshot 2024-09-27 231925](https://github.com/user-attachments/assets/729fca3c-1cef-4a4d-a02e-704bda0de7eb)
